### PR TITLE
link packagekit via pkconfig and add pkconfig to include path.

### DIFF
--- a/ornplugin.pro
+++ b/ornplugin.pro
@@ -1,11 +1,13 @@
 TEMPLATE = lib
 TARGET = ornplugin
 QT += qml quick
-CONFIG += qt plugin static c++11
+
+CONFIG += qt plugin static c++11 link_pkgconfig
 CONFIG(release, debug|release): DEFINES += QT_NO_DEBUG_OUTPUT
 VERSION = 0.1
-
 TARGET = $$qtLibraryTarget($$TARGET)
+PKGCONFIG+= packagekitqt5
+INCLUDEPATH+= /usr/include/packagekitqt5/
 
 uri = harbour.orn
 

--- a/src/ornzypp.h
+++ b/src/ornzypp.h
@@ -4,7 +4,7 @@
 #include <QObject>
 #include <QSet>
 
-#include <PackageKit/packagekit-qt5/Transaction>
+#include <PackageKit/Transaction>
 
 class QDBusPendingCallWatcher;
 class QQmlEngine;


### PR DESCRIPTION
For some reason pkgconfig returns the wrong include path so I added
the include path direct. (see PaketeKit-Qt Bug [#26](https://github.com/hughsie/PackageKit-Qt/issues/26)).-